### PR TITLE
Allow custom timing values

### DIFF
--- a/source/AnchorScroller.ts
+++ b/source/AnchorScroller.ts
@@ -1,14 +1,20 @@
 import Scroller from './Scroller';
 
 
-export interface animationFunction {
-  (time: number, start: number, change: number, duration: number): number
+export interface CustomAnimation {
+  (time?: number, start?: number, change?: number, duration?: number): number
+}
+
+export interface TimeOptions {
+  increment?: number;
+  duration?: number;
 }
 
 export interface Options {
   checkParent?: boolean;
   class?: string;
-  animation?: animationFunction;
+  animation?: CustomAnimation;
+  time?: TimeOptions;
 }
 
 interface BoundEventHandlers {
@@ -36,6 +42,7 @@ class AnchorScroller {
       checkParent: false,
       class: undefined,
       animation: undefined,
+      time: undefined,
       ...optionalOptions
     };
     this.addListeners();
@@ -100,7 +107,10 @@ class AnchorScroller {
     // is not equal to the anchors' position
     event.preventDefault();
     if (window.scrollY !== anchor.offsetTop) {
-      new Scroller(anchor.offsetTop, this.options.animation);
+      new Scroller(anchor.offsetTop, {
+        customAnimation: this.options.animation,
+        time: this.options.time
+      });
     }
   }
 

--- a/source/Scroller.ts
+++ b/source/Scroller.ts
@@ -1,4 +1,9 @@
-import { animationFunction } from './AnchorScroller';
+import { CustomAnimation, TimeOptions } from './AnchorScroller';
+
+interface ScrollerOptions {
+  customAnimation?: CustomAnimation;
+  time?: TimeOptions
+}
 
 /**
  * Handles the scrolling
@@ -30,7 +35,9 @@ class Scroller {
   /**
    * Duration of the scrolling
    */
-  private duration: number = 1500;
+  private duration: number = this.options.time && this.options.time.duration
+    ? this.options.time.duration
+    : 1500;
 
   /**
    * Start position
@@ -45,7 +52,9 @@ class Scroller {
   /**
    * Time increments
    */
-  private increment: number = 25;
+  private increment: number = this.options.time && this.options.time.increment
+    ? this.options.time.increment
+    : 25;
 
   /**
    * Bound copy of the scroll function.
@@ -54,7 +63,7 @@ class Scroller {
   private scroll = this.scrollUnbound.bind(this);
 
 
-  constructor(private position: number, private customAnimation?: animationFunction) {
+  constructor(private position: number, private options: ScrollerOptions) {
     requestAnimationFrame(this.scroll);
   }
 
@@ -86,7 +95,7 @@ class Scroller {
 
     window.scroll(
       window.scrollX,
-      this.customAnimation ? this.customAnimation(this.time, this.start, this.change, this.duration) : this.ease(this.time, this.start, this.change, this.duration)
+      this.options.customAnimation ? this.options.customAnimation(this.time, this.start, this.change, this.duration) : this.ease(this.time, this.start, this.change, this.duration)
     );
 
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,11 +1,17 @@
 export interface animationFunction {
-  (time: number, start: number, change: number, duration: number): number
+  (time?: number, start?: number, change?: number, duration?: number): number
+}
+
+export interface TimeOptions {
+  increments?: number;
+  duration?: number;
 }
 
 export interface Options {
   checkParent?: boolean;
   class?: string;
   animation?: animationFunction;
+  time?: TimeOptions;
 }
 
 declare class AnchorScroller {


### PR DESCRIPTION
Users can specify their own timing values in the AnchorScroll options parameter,

example (with default values)
```typescript
new AnchorScroller({
  time: {
    increment: 25,
    duration: 1500
  }
)}
```